### PR TITLE
Upgrade to OkHttp3.

### DIFF
--- a/okhttputils/build.gradle
+++ b/okhttputils/build.gradle
@@ -132,5 +132,5 @@ makeJar.dependsOn(clearJar, build)
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.squareup.okhttp:okhttp:2.5.0'
+    compile 'com.squareup.okhttp3:okhttp:3.0.0-RC1'
 }

--- a/okhttputils/src/main/java/com/zhy/http/okhttp/builder/GetBuilder.java
+++ b/okhttputils/src/main/java/com/zhy/http/okhttp/builder/GetBuilder.java
@@ -3,7 +3,7 @@ package com.zhy.http.okhttp.builder;
 import com.zhy.http.okhttp.request.GetRequest;
 import com.zhy.http.okhttp.request.RequestCall;
 
-import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -64,7 +64,7 @@ public class GetBuilder extends OkHttpRequestBuilder
     {
         if (this.params == null)
         {
-            params = new IdentityHashMap<>();
+            params = new LinkedHashMap<>();
         }
         params.put(key, val);
         return this;
@@ -82,7 +82,7 @@ public class GetBuilder extends OkHttpRequestBuilder
     {
         if (this.headers == null)
         {
-            headers = new IdentityHashMap<>();
+            headers = new LinkedHashMap<>();
         }
         headers.put(key, val);
         return this;

--- a/okhttputils/src/main/java/com/zhy/http/okhttp/builder/PostFileBuilder.java
+++ b/okhttputils/src/main/java/com/zhy/http/okhttp/builder/PostFileBuilder.java
@@ -1,11 +1,11 @@
 package com.zhy.http.okhttp.builder;
 
-import com.squareup.okhttp.MediaType;
+import okhttp3.MediaType;
 import com.zhy.http.okhttp.request.PostFileRequest;
 import com.zhy.http.okhttp.request.RequestCall;
 
 import java.io.File;
-import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -62,7 +62,7 @@ public class PostFileBuilder extends OkHttpRequestBuilder
     {
         if (this.params == null)
         {
-            params = new IdentityHashMap<>();
+            params = new LinkedHashMap<>();
         }
         params.put(key, val);
         return this;
@@ -80,7 +80,7 @@ public class PostFileBuilder extends OkHttpRequestBuilder
     {
         if (this.headers == null)
         {
-            headers = new IdentityHashMap<>();
+            headers = new LinkedHashMap<>();
         }
         headers.put(key, val);
         return this;

--- a/okhttputils/src/main/java/com/zhy/http/okhttp/builder/PostFormBuilder.java
+++ b/okhttputils/src/main/java/com/zhy/http/okhttp/builder/PostFormBuilder.java
@@ -5,7 +5,7 @@ import com.zhy.http.okhttp.request.RequestCall;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -69,7 +69,7 @@ public class PostFormBuilder extends OkHttpRequestBuilder
     {
         if (this.params == null)
         {
-            params = new IdentityHashMap<>();
+            params = new LinkedHashMap<>();
         }
         params.put(key, val);
         return this;
@@ -87,7 +87,7 @@ public class PostFormBuilder extends OkHttpRequestBuilder
     {
         if (this.headers == null)
         {
-            headers = new IdentityHashMap<>();
+            headers = new LinkedHashMap<>();
         }
         headers.put(key, val);
         return this;

--- a/okhttputils/src/main/java/com/zhy/http/okhttp/builder/PostStringBuilder.java
+++ b/okhttputils/src/main/java/com/zhy/http/okhttp/builder/PostStringBuilder.java
@@ -1,10 +1,10 @@
 package com.zhy.http.okhttp.builder;
 
-import com.squareup.okhttp.MediaType;
+import okhttp3.MediaType;
 import com.zhy.http.okhttp.request.PostStringRequest;
 import com.zhy.http.okhttp.request.RequestCall;
 
-import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -61,7 +61,7 @@ public class PostStringBuilder extends OkHttpRequestBuilder
     {
         if (this.params == null)
         {
-            params = new IdentityHashMap<>();
+            params = new LinkedHashMap<>();
         }
         params.put(key, val);
         return this;
@@ -79,7 +79,7 @@ public class PostStringBuilder extends OkHttpRequestBuilder
     {
         if (this.headers == null)
         {
-            headers = new IdentityHashMap<>();
+            headers = new LinkedHashMap<>();
         }
         headers.put(key, val);
         return this;

--- a/okhttputils/src/main/java/com/zhy/http/okhttp/callback/BitmapCallback.java
+++ b/okhttputils/src/main/java/com/zhy/http/okhttp/callback/BitmapCallback.java
@@ -3,7 +3,7 @@ package com.zhy.http.okhttp.callback;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 
-import com.squareup.okhttp.Response;
+import okhttp3.Response;
 
 import java.io.IOException;
 

--- a/okhttputils/src/main/java/com/zhy/http/okhttp/callback/Callback.java
+++ b/okhttputils/src/main/java/com/zhy/http/okhttp/callback/Callback.java
@@ -1,7 +1,7 @@
 package com.zhy.http.okhttp.callback;
 
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.Response;
+import okhttp3.Request;
+import okhttp3.Response;
 
 import java.io.IOException;
 

--- a/okhttputils/src/main/java/com/zhy/http/okhttp/callback/FileCallBack.java
+++ b/okhttputils/src/main/java/com/zhy/http/okhttp/callback/FileCallBack.java
@@ -1,6 +1,6 @@
 package com.zhy.http.okhttp.callback;
 
-import com.squareup.okhttp.Response;
+import okhttp3.Response;
 import com.zhy.http.okhttp.OkHttpUtils;
 import com.zhy.http.okhttp.utils.L;
 

--- a/okhttputils/src/main/java/com/zhy/http/okhttp/callback/StringCallback.java
+++ b/okhttputils/src/main/java/com/zhy/http/okhttp/callback/StringCallback.java
@@ -1,6 +1,6 @@
 package com.zhy.http.okhttp.callback;
 
-import com.squareup.okhttp.Response;
+import okhttp3.Response;
 
 import java.io.IOException;
 

--- a/okhttputils/src/main/java/com/zhy/http/okhttp/cookie/PersistentCookieStore.java
+++ b/okhttputils/src/main/java/com/zhy/http/okhttp/cookie/PersistentCookieStore.java
@@ -15,10 +15,11 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * <pre>
- *     OkHttpClient client = new OkHttpClient();
- *     client.setCookieHandler(new CookieManager(
- *                new PersistentCookieStore(getApplicationContext()),
- *                   CookiePolicy.ACCEPT_ALL));
+ *     OkHttpClient client = new OkHttpClient.Builder()
+ *             .cookieJar(new JavaNetCookieJar(new CookieManager(
+ *                     new PersistentCookieStore(getApplicationContext()),
+ *                             CookiePolicy.ACCEPT_ALL))
+ *             .build();
  *
  * </pre>
  * <p/>

--- a/okhttputils/src/main/java/com/zhy/http/okhttp/cookie/SimpleCookieJar.java
+++ b/okhttputils/src/main/java/com/zhy/http/okhttp/cookie/SimpleCookieJar.java
@@ -1,0 +1,33 @@
+package com.zhy.http.okhttp.cookie;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import okhttp3.Cookie;
+import okhttp3.CookieJar;
+import okhttp3.HttpUrl;
+
+public final class SimpleCookieJar implements CookieJar
+{
+    private final List<Cookie> allCookies = new ArrayList<>();
+
+    @Override
+    public synchronized void saveFromResponse(HttpUrl url, List<Cookie> cookies)
+    {
+        allCookies.addAll(cookies);
+    }
+
+    @Override
+    public synchronized List<Cookie> loadForRequest(HttpUrl url)
+    {
+        List<Cookie> result = new ArrayList<>();
+        for (Cookie cookie : allCookies)
+        {
+            if (cookie.matches(url))
+            {
+                result.add(cookie);
+            }
+        }
+        return result;
+    }
+}

--- a/okhttputils/src/main/java/com/zhy/http/okhttp/https/HttpsUtils.java
+++ b/okhttputils/src/main/java/com/zhy/http/okhttp/https/HttpsUtils.java
@@ -1,7 +1,5 @@
 package com.zhy.http.okhttp.https;
 
-import com.squareup.okhttp.OkHttpClient;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.KeyManagementException;
@@ -17,6 +15,7 @@ import java.security.cert.X509Certificate;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
@@ -26,7 +25,7 @@ import javax.net.ssl.X509TrustManager;
  */
 public class HttpsUtils
 {
-    public static void setCertificates(OkHttpClient okHttpClient, InputStream[] certificates, InputStream bksFile, String password)
+    public static SSLSocketFactory getSslSocketFactory(InputStream[] certificates, InputStream bksFile, String password)
     {
         try
         {
@@ -35,16 +34,16 @@ public class HttpsUtils
             SSLContext sslContext = SSLContext.getInstance("TLS");
 
             sslContext.init(keyManagers, new TrustManager[]{new MyTrustManager(chooseTrustManager(trustManagers))}, new SecureRandom());
-            okHttpClient.setSslSocketFactory(sslContext.getSocketFactory());
+            return sslContext.getSocketFactory();
         } catch (NoSuchAlgorithmException e)
         {
-            e.printStackTrace();
+            throw new AssertionError(e);
         } catch (KeyManagementException e)
         {
-            e.printStackTrace();
+            throw new AssertionError(e);
         } catch (KeyStoreException e)
         {
-            e.printStackTrace();
+            throw new AssertionError(e);
         }
     }
 

--- a/okhttputils/src/main/java/com/zhy/http/okhttp/request/CountingRequestBody.java
+++ b/okhttputils/src/main/java/com/zhy/http/okhttp/request/CountingRequestBody.java
@@ -1,7 +1,7 @@
 package com.zhy.http.okhttp.request;
 
-import com.squareup.okhttp.MediaType;
-import com.squareup.okhttp.RequestBody;
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
 
 import java.io.IOException;
 

--- a/okhttputils/src/main/java/com/zhy/http/okhttp/request/GetRequest.java
+++ b/okhttputils/src/main/java/com/zhy/http/okhttp/request/GetRequest.java
@@ -1,7 +1,7 @@
 package com.zhy.http.okhttp.request;
 
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.RequestBody;
+import okhttp3.Request;
+import okhttp3.RequestBody;
 
 import java.util.Map;
 

--- a/okhttputils/src/main/java/com/zhy/http/okhttp/request/OkHttpRequest.java
+++ b/okhttputils/src/main/java/com/zhy/http/okhttp/request/OkHttpRequest.java
@@ -1,8 +1,8 @@
 package com.zhy.http.okhttp.request;
 
-import com.squareup.okhttp.Headers;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.RequestBody;
+import okhttp3.Headers;
+import okhttp3.Request;
+import okhttp3.RequestBody;
 import com.zhy.http.okhttp.callback.Callback;
 import com.zhy.http.okhttp.utils.Exceptions;
 

--- a/okhttputils/src/main/java/com/zhy/http/okhttp/request/PostFileRequest.java
+++ b/okhttputils/src/main/java/com/zhy/http/okhttp/request/PostFileRequest.java
@@ -1,8 +1,8 @@
 package com.zhy.http.okhttp.request;
 
-import com.squareup.okhttp.MediaType;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.RequestBody;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
 import com.zhy.http.okhttp.utils.Exceptions;
 
 import java.io.File;

--- a/okhttputils/src/main/java/com/zhy/http/okhttp/request/PostFormRequest.java
+++ b/okhttputils/src/main/java/com/zhy/http/okhttp/request/PostFormRequest.java
@@ -1,11 +1,11 @@
 package com.zhy.http.okhttp.request;
 
-import com.squareup.okhttp.FormEncodingBuilder;
-import com.squareup.okhttp.Headers;
-import com.squareup.okhttp.MediaType;
-import com.squareup.okhttp.MultipartBuilder;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.RequestBody;
+import okhttp3.FormBody;
+import okhttp3.Headers;
+import okhttp3.MediaType;
+import okhttp3.MultipartBody;
+import okhttp3.Request;
+import okhttp3.RequestBody;
 import com.zhy.http.okhttp.OkHttpUtils;
 import com.zhy.http.okhttp.builder.PostFormBuilder;
 import com.zhy.http.okhttp.callback.Callback;
@@ -33,13 +33,13 @@ public class PostFormRequest extends OkHttpRequest
     {
         if (files == null || files.isEmpty())
         {
-            FormEncodingBuilder builder = new FormEncodingBuilder();
+            FormBody.Builder builder = new FormBody.Builder();
             addParams(builder);
             return builder.build();
         } else
         {
-            MultipartBuilder builder = new MultipartBuilder()
-                    .type(MultipartBuilder.FORM);
+            MultipartBody.Builder builder = new MultipartBody.Builder()
+                    .setType(MultipartBody.FORM);
             addParams(builder);
 
             for (int i = 0; i < files.size(); i++)
@@ -93,7 +93,7 @@ public class PostFormRequest extends OkHttpRequest
         return contentTypeFor;
     }
 
-    private void addParams(MultipartBuilder builder)
+    private void addParams(MultipartBody.Builder builder)
     {
         if (params != null && !params.isEmpty())
         {
@@ -105,7 +105,7 @@ public class PostFormRequest extends OkHttpRequest
         }
     }
 
-    private void addParams(FormEncodingBuilder builder)
+    private void addParams(FormBody.Builder builder)
     {
         if (params == null || params.isEmpty())
         {

--- a/okhttputils/src/main/java/com/zhy/http/okhttp/request/PostStringRequest.java
+++ b/okhttputils/src/main/java/com/zhy/http/okhttp/request/PostStringRequest.java
@@ -1,8 +1,8 @@
 package com.zhy.http.okhttp.request;
 
-import com.squareup.okhttp.MediaType;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.RequestBody;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
 import com.zhy.http.okhttp.utils.Exceptions;
 
 import java.util.Map;

--- a/okhttputils/src/main/java/com/zhy/http/okhttp/request/RequestCall.java
+++ b/okhttputils/src/main/java/com/zhy/http/okhttp/request/RequestCall.java
@@ -1,9 +1,9 @@
 package com.zhy.http.okhttp.request;
 
-import com.squareup.okhttp.Call;
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.Response;
+import okhttp3.Call;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 import com.zhy.http.okhttp.OkHttpUtils;
 import com.zhy.http.okhttp.callback.Callback;
 
@@ -56,15 +56,15 @@ public class RequestCall
 
         if (readTimeOut > 0 || writeTimeOut > 0 || connTimeOut > 0)
         {
-            cloneClient();
-
             readTimeOut = readTimeOut > 0 ? readTimeOut : OkHttpUtils.DEFAULT_MILLISECONDS;
             writeTimeOut = writeTimeOut > 0 ? writeTimeOut : OkHttpUtils.DEFAULT_MILLISECONDS;
             connTimeOut = connTimeOut > 0 ? connTimeOut : OkHttpUtils.DEFAULT_MILLISECONDS;
 
-            clone.setReadTimeout(readTimeOut, TimeUnit.MILLISECONDS);
-            clone.setWriteTimeout(writeTimeOut, TimeUnit.MILLISECONDS);
-            clone.setConnectTimeout(connTimeOut, TimeUnit.MILLISECONDS);
+            clone = OkHttpUtils.getInstance().getOkHttpClient().newBuilder()
+                    .readTimeout(readTimeOut, TimeUnit.MILLISECONDS)
+                    .writeTimeout(writeTimeOut, TimeUnit.MILLISECONDS)
+                    .connectTimeout(connTimeOut, TimeUnit.MILLISECONDS)
+                    .build();
 
             call = clone.newCall(request);
         } else
@@ -110,12 +110,6 @@ public class RequestCall
     {
         generateCall(null);
         return call.execute();
-    }
-
-
-    private void cloneClient()
-    {
-        clone = OkHttpUtils.getInstance().getOkHttpClient().clone();
     }
 
     public void cancel()

--- a/sample-okhttp/src/main/java/com/zhy/sample_okhttp/ListUserCallback.java
+++ b/sample-okhttp/src/main/java/com/zhy/sample_okhttp/ListUserCallback.java
@@ -1,7 +1,7 @@
 package com.zhy.sample_okhttp;
 
 import com.google.gson.Gson;
-import com.squareup.okhttp.Response;
+import okhttp3.Response;
 import com.zhy.http.okhttp.callback.Callback;
 
 import java.io.IOException;

--- a/sample-okhttp/src/main/java/com/zhy/sample_okhttp/MainActivity.java
+++ b/sample-okhttp/src/main/java/com/zhy/sample_okhttp/MainActivity.java
@@ -12,7 +12,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.google.gson.Gson;
-import com.squareup.okhttp.Request;
+import okhttp3.Request;
 import com.zhy.http.okhttp.OkHttpUtils;
 import com.zhy.http.okhttp.callback.BitmapCallback;
 import com.zhy.http.okhttp.callback.FileCallBack;

--- a/sample-okhttp/src/main/java/com/zhy/sample_okhttp/MyApplication.java
+++ b/sample-okhttp/src/main/java/com/zhy/sample_okhttp/MyApplication.java
@@ -37,7 +37,7 @@ public class MyApplication extends Application
                 new Buffer()
                         .writeUtf8(CER_12306)
                         .inputStream()});
-        OkHttpUtils.getInstance().debug("testDebug").getOkHttpClient().setConnectTimeout(100000, TimeUnit.MILLISECONDS);
+        OkHttpUtils.getInstance().debug("testDebug").setConnectTimeout(100000, TimeUnit.MILLISECONDS);
 
 
     }

--- a/sample-okhttp/src/main/java/com/zhy/sample_okhttp/UserCallback.java
+++ b/sample-okhttp/src/main/java/com/zhy/sample_okhttp/UserCallback.java
@@ -1,7 +1,7 @@
 package com.zhy.sample_okhttp;
 
 import com.google.gson.Gson;
-import com.squareup.okhttp.Response;
+import okhttp3.Response;
 import com.zhy.http.okhttp.callback.Callback;
 
 import java.io.IOException;


### PR DESCRIPTION
The persistent cookie store is not updated and needs to use OkHttp's shim
called JavaNetCookieJar which is in the okhttp-urlconnection module. It's
relatively straightforward to change PersistentCookieStore to implement
CookieJar instead, but I'm leaving this up to the project owners.